### PR TITLE
Delete past screenshot request

### DIFF
--- a/app/controllers/screenshotreqs_controller.rb
+++ b/app/controllers/screenshotreqs_controller.rb
@@ -4,10 +4,9 @@ class ScreenshotreqsController < ApplicationController
   # functions for Screenshot requests and Screenshots.
   
   def index
+    @screenshotreqs = Screenshotreq.all
     # index method sends all screenshot request params to the front page: 
     # ./app/views/screenshotreqs/index.html.erb
-    
-    @screenshotreqs = Screenshotreq.all
   end
   
   # Do I need this method??
@@ -16,6 +15,7 @@ class ScreenshotreqsController < ApplicationController
   end
 
   def create
+    @screenshotreq = Screenshotreq.new(screenshotreq_params)
     # Create method creates a new instance of a Screenshot Request 
     # to be populated with data submitted from the form in new.html.erb.  
     # When the "submit request" button on the form is clicked, the method 
@@ -23,8 +23,6 @@ class ScreenshotreqsController < ApplicationController
     # the validation criteria in ./app/models/screenshotreq.rb, then .save 
     # is successful and parse_urls and create_screenshots methods are run.  Also
     # after save, the view redirects to the home page.
-    
-    @screenshotreq = Screenshotreq.new(screenshotreq_params)
     
     if @screenshotreq.save
       parse_urls
@@ -39,12 +37,21 @@ class ScreenshotreqsController < ApplicationController
   end
 
   def show
+    @screenshotreq = Screenshotreq.find(params[:id])
     # show method reads the information of a previously saved screenshot 
     # request in the database, and sends that information to a new view 
     # page defined by ./app/views/screenshotreqs/show.html.erb. The particular 
     # screenshotreq read from the database is identified by id parameter.
+  end
 
+  def destroy
     @screenshotreq = Screenshotreq.find(params[:id])
+    @screenshotreq.destroy
+   
+    redirect_to root_path
+    # Redirect view to home page after delete
+
+    flash[:notice] = 'Screenshot request history has been deleted.'
   end
 
   private
@@ -52,10 +59,9 @@ class ScreenshotreqsController < ApplicationController
   # of this controller.
 
   def screenshotreq_params
+    params.require(:screenshotreq).permit(:name, :urls)
     # screenshot_params method is used to enable the create method to 
     # save screenshot requests with name and urls params.
-
-    params.require(:screenshotreq).permit(:name, :urls)
   end
 
   def parse_urls
@@ -75,11 +81,12 @@ class ScreenshotreqsController < ApplicationController
       @screenshot.screenshotreq = @screenshotreq
       @screenshot.save!
       counter += 1
+      # Saves each individual URL from the list of URLs into separate 
+      # screenshot instances.  url is the parameter to be passed to the 
+      # screenshot capture method which determines the webpage URL to 
+      # screenshot, img_path is the location where the image file of the 
+      # screenshot will be stored, and img_path_short is the name of the image file.
     end
-    # saves each individual URL from the list of URLs into separate Screenshot instances.
-    # url is the parameter used by the screenshot capture method which determines the webpage to screenshot,
-    # img_path is the location where the image file of the screenshot will be stored, and
-    # img_path_short is the name of the image file.
 
   end
 
@@ -93,10 +100,14 @@ class ScreenshotreqsController < ApplicationController
     @screenshotreq.screenshots.each do |screenshot|
       ws.capture screenshot.url, screenshot.img_path, width: 1024, height: 768
       screenshot.image.attach(io: File.open(screenshot.img_path), filename: screenshot.img_path_short)
+      # use the ws.capture helper method to capture each screenshot 
+      # associated with the screenshotreq instance. Inputs for the 
+      # capture include the screenshot URL and the image path where 
+      # the image will be saved. Finally, the new screenshot image is 
+      # associated with the screenshot instance using the .attach method
+      # native to Rails Active Storage.
     end
-    # use the ws.capture helper method for each screenshot for an associated screenshotreq,
-    # at the specified URL, giving the image the img_path file name.
 
-    flash[:notice] = 'The screenshots have been generated and saved.'
+    flash[:notice] = 'The screenshots have been caputured and saved.'
   end
 end

--- a/app/controllers/screenshotreqs_controller.rb
+++ b/app/controllers/screenshotreqs_controller.rb
@@ -51,7 +51,7 @@ class ScreenshotreqsController < ApplicationController
     redirect_to root_path
     # Redirect view to home page after delete
 
-    flash[:notice] = 'Screenshot request history has been deleted.'
+    flash[:notice] = 'Screenshot request has been deleted.'
   end
 
   private

--- a/app/models/screenshotreq.rb
+++ b/app/models/screenshotreq.rb
@@ -5,6 +5,7 @@ class Screenshotreq < ApplicationRecord
   validates :urls, presence: true
 
   # Each screenshot request will have at least one screenshot
-  has_many :screenshots
+  # When a screenshot request is deleted, it will deleted the associated screenshots
+  has_many :screenshots, dependent: :destroy
   
 end

--- a/app/views/screenshotreqs/index.html.erb
+++ b/app/views/screenshotreqs/index.html.erb
@@ -7,6 +7,6 @@ to see request URLs and screenshot images %>
 <h3>Stored Requests</h3>
 <% @screenshotreqs.each do |request| %>
   <div>
-    <p><%= request.name %>. <%= link_to 'Show', screenshotreq_path(request) %> 
+    <p><%= request.name %>. <%= link_to 'Show', screenshotreq_path(request) %> &nbsp; <%= link_to 'Delete', screenshotreq_path(request), method: :delete%>
   </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
   root controller: :screenshotreqs, action: :index
-  resources :screenshotreqs, only: [:index, :create, :new, :show]
+  resources :screenshotreqs
 end


### PR DESCRIPTION
There are plenty of reasons to want to delete a save screenshot request...

1. Open route for `delete` method.
2. Define `delete` method in `screenshotreqs` controller.
3. Add `Delete` link in `index` view.
4. Have associated `screenshots` be deleted when `screenshotreq` is deleted.