### PR TITLE
[MA01.3] Production Release Fix

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,10 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
     <title>Browsershot</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>


### PR DESCRIPTION
## Summary
[[MA01.0] Production Release](https://github.com/maxAubain/DTC_screenshot/pull/14)
- This is a bug fix PR.  See **Challenges and Solutions**.

## Dependencies / Libraries
N/A

## UI
N/A

## Challenges and Solutions
- **Bug**: Using browser dev tools on a local-server deployment of Browsershot, the media queries established in the CSS files to check view width would trigger appropriately.  This means, when the browser window would be manually shrunk to a mobile screen width, mobile layout styles would show.  However, when the app was deployed to the cloud and accessed by an actual mobile device, only the desktop layout styles would be visible.
- **Fix**: Likely the issue is a lack of needed `<meta>` tag in the `<header>` of `index.html` to set the properties of the viewport. `
```
<meta name="viewport" content="width=device-width,initial-scale=1.0">
```
`shrint-to-fit=no` is also added as a parameter as it comes standard with a new React app.

## References
**Challenges and Solutions**
- https://stackoverflow.com/questions/17344339/media-query-not-working-in-mobile-works-fine-in-chrome
